### PR TITLE
fix(orchestration): emit libs to flat dir, drop per-config namespacing

### DIFF
--- a/src/te_builder/cli.py
+++ b/src/te_builder/cli.py
@@ -30,10 +30,9 @@ from .cmake import discover_cmaker
 from .config import Env, ProjectSpec, load_presets
 from .msbuild import discover_sln, validate_configuration
 from .orchestration import (
-    cleanup_libs_for_configuration,
-    configuration_lib_dir,
     copy_libs_for_configuration,
     prepare_log_file,
+    project_lib_dir,
     retry_build,
 )
 from .runner import run
@@ -302,13 +301,12 @@ def _build_loop(env: Env) -> tuple[list[StatusRow], int]:
                 row = _build_with_cmaker(env, project, project_dir, cmaker)
             else:
                 _logger.debug("build [%s] config=[%s]", project.name, label)
-                cleanup_libs_for_configuration(project_dir, label, env.project_defaults)
                 row = _build_one(env, project, project_dir, label)
                 if row.ok:
                     copy_libs_for_configuration(project_dir, label, env.project_defaults)
                     _logger.debug(
                         "artifacts in %s",
-                        configuration_lib_dir(project_dir, label, env.project_defaults),
+                        project_lib_dir(project_dir, env.project_defaults),
                     )
             rows.append(row)
             if not row.ok:

--- a/src/te_builder/orchestration.py
+++ b/src/te_builder/orchestration.py
@@ -1,10 +1,12 @@
 """Build orchestration helpers used by the CLI loop.
 
-The legacy code mixed three responsibilities in one block: cleaning up the
-previous configuration's output, dispatching to MSBuild or cmake, and
-copying the result back into a shared `libs/` directory. The shared dir
-made it impossible to keep both Release and Debug-MTDLL outputs around at
-the same time. We now namespace by configuration.
+te-external solution files emit configuration-suffixed artifact names
+(e.g. zlib-debug-mtdll-x64.lib vs zlib-release-mtdll-x64.lib), so Debug
+and Release outputs already coexist safely in a single flat libs/ dir.
+Downstream consumers (libpng, freetype, ...) reference dependencies via
+flat libs/<dep>/<name>.lib paths through junctions, so the flat layout
+is the contract te-builder must preserve — without it those consumers
+fail to link unless te-builder is re-run.
 """
 
 from __future__ import annotations
@@ -19,25 +21,16 @@ from .config import ProjectDefaults
 _logger = logging.getLogger(__name__)
 
 
-def _configuration_dir_name(configuration: str) -> str:
-    """`Release|x64` is not a legal directory name on Windows. We replace
-    the pipe with a dash, matching the log-file naming used elsewhere."""
-    return configuration.replace("|", "-")
-
-
-def configuration_lib_dir(
-    project_dir: Path, configuration: str, defaults: ProjectDefaults
-) -> Path:
-    return project_dir / defaults.output_libs / _configuration_dir_name(configuration)
+def project_lib_dir(project_dir: Path, defaults: ProjectDefaults) -> Path:
+    return project_dir / defaults.output_libs
 
 
 def copy_libs_for_configuration(
     project_dir: Path, configuration: str, defaults: ProjectDefaults
 ) -> None:
-    output_dir = configuration_lib_dir(project_dir, configuration, defaults)
+    del configuration  # output filenames already encode the configuration
+    output_dir = project_lib_dir(project_dir, defaults)
     output_dir.mkdir(parents=True, exist_ok=True)
-    flat_dir = project_dir / defaults.output_libs
-    flat_dir.mkdir(parents=True, exist_ok=True)
     for pattern in defaults.copy:
         for source in project_dir.glob(pattern):
             if not source.is_file():
@@ -45,19 +38,6 @@ def copy_libs_for_configuration(
             target = output_dir / source.name
             _logger.debug("copy %s -> %s", source, target)
             shutil.copy(str(source), str(target))
-            shutil.copy(str(source), str(flat_dir / source.name))
-
-
-def cleanup_libs_for_configuration(
-    project_dir: Path, configuration: str, defaults: ProjectDefaults
-) -> None:
-    output_dir = configuration_lib_dir(project_dir, configuration, defaults)
-    if not output_dir.exists():
-        return
-    for entry in list(output_dir.iterdir()):
-        if entry.is_file():
-            _logger.debug("remove %s", entry)
-            entry.unlink()
 
 
 def prepare_log_file(log_file: Path) -> None:

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,11 +1,17 @@
 """Tests for the build-orchestration helpers.
 
-Two legacy bugs are pinned here:
-- `copy_libs` wrote all configurations into one `libs/` directory, so a
-  later configuration silently overwrote an earlier one. We now namespace
-  by configuration.
+Legacy bugs pinned here:
 - The retry loop summed return codes from every attempt and never broke
   on a successful retry. We break on the first success.
+- prepare_log_file must wipe stale logs so summarize_from_log() never
+  reports a previous run's "0 Error(s)" against a failed build.
+
+Layout note: copy_libs_for_configuration writes to a flat libs/ dir.
+te-external solution files emit configuration-suffixed filenames
+(e.g. zlib-debug-mtdll-x64.lib), so Debug and Release artifacts coexist
+without collision, and downstream consumers (libpng, freetype) can link
+against libs/*.lib through junctions without depending on te-builder
+to mirror files into a per-configuration subdir.
 """
 
 from __future__ import annotations
@@ -14,7 +20,6 @@ from pathlib import Path
 
 from te_builder.config import ProjectDefaults
 from te_builder.orchestration import (
-    cleanup_libs_for_configuration,
     copy_libs_for_configuration,
     prepare_log_file,
     retry_build,
@@ -25,55 +30,38 @@ def _fake_project(tmp_path: Path) -> Path:
     project_dir = tmp_path / "fake-lib"
     output = project_dir / "projects" / "output"
     output.mkdir(parents=True)
-    (output / "fake.lib").write_text("a", encoding="utf-8")
-    (output / "fake.dll").write_text("b", encoding="utf-8")
+    (output / "fake-release-mtdll-x64.lib").write_text("a", encoding="utf-8")
+    (output / "fake-release-mtdll-x64.dll").write_text("b", encoding="utf-8")
     return project_dir
 
 
-def test_copy_libs_namespaces_by_configuration(tmp_path: Path) -> None:
+def test_copy_libs_writes_flat(tmp_path: Path) -> None:
     project_dir = _fake_project(tmp_path)
     defaults = ProjectDefaults()
-    copy_libs_for_configuration(project_dir, "Release|x64", defaults)
-    copied = sorted((project_dir / "libs" / "Release-x64").iterdir())
-    assert [path.name for path in copied] == ["fake.dll", "fake.lib"]
+    copy_libs_for_configuration(project_dir, "Release-MTDLL|x64", defaults)
+    copied = sorted((project_dir / "libs").glob("*"))
+    assert [path.name for path in copied] == [
+        "fake-release-mtdll-x64.dll",
+        "fake-release-mtdll-x64.lib",
+    ]
 
 
-def test_copy_libs_also_mirrors_flat(tmp_path: Path) -> None:
-    """te-external project files reference dependency libs via flat
-    libs/*.lib paths (e.g. libpng's AdditionalLibraryDirectories points
-    at libs/zlib via a junction). The flat mirror keeps that consumer
-    working while the per-config subdirs preserve both Release and Debug
-    side by side."""
-    project_dir = _fake_project(tmp_path)
+def test_copy_libs_both_configurations_coexist(tmp_path: Path) -> None:
+    """Configuration-suffixed filenames let Debug and Release coexist in
+    the flat libs/ dir without overwriting each other."""
+    project_dir = tmp_path / "fake-lib"
+    output = project_dir / "projects" / "output"
+    output.mkdir(parents=True)
+    (output / "fake-release-mtdll-x64.lib").write_text("rel", encoding="utf-8")
     defaults = ProjectDefaults()
-    copy_libs_for_configuration(project_dir, "Release|x64", defaults)
-    flat = sorted((project_dir / "libs").glob("*.lib"))
-    assert [path.name for path in flat] == ["fake.lib"]
+    copy_libs_for_configuration(project_dir, "Release-MTDLL|x64", defaults)
 
-
-def test_copy_libs_two_configurations_do_not_collide(tmp_path: Path) -> None:
-    project_dir = _fake_project(tmp_path)
-    defaults = ProjectDefaults()
-    copy_libs_for_configuration(project_dir, "Release|x64", defaults)
-    # rebuild produces new artifacts in the same output dir
-    (project_dir / "projects" / "output" / "fake.dll").write_text(
-        "debug", encoding="utf-8"
-    )
+    (output / "fake-debug-mtdll-x64.lib").write_text("dbg", encoding="utf-8")
     copy_libs_for_configuration(project_dir, "Debug-MTDLL|x64", defaults)
-    release_dll = (project_dir / "libs" / "Release-x64" / "fake.dll").read_text()
-    debug_dll = (project_dir / "libs" / "Debug-MTDLL-x64" / "fake.dll").read_text()
-    assert release_dll == "b"
-    assert debug_dll == "debug"
 
-
-def test_cleanup_libs_scoped_to_configuration(tmp_path: Path) -> None:
-    project_dir = _fake_project(tmp_path)
-    defaults = ProjectDefaults()
-    copy_libs_for_configuration(project_dir, "Release|x64", defaults)
-    copy_libs_for_configuration(project_dir, "Debug-MTDLL|x64", defaults)
-    cleanup_libs_for_configuration(project_dir, "Release|x64", defaults)
-    assert not (project_dir / "libs" / "Release-x64" / "fake.lib").exists()
-    assert (project_dir / "libs" / "Debug-MTDLL-x64" / "fake.lib").exists()
+    libs = project_dir / "libs"
+    assert (libs / "fake-release-mtdll-x64.lib").read_text() == "rel"
+    assert (libs / "fake-debug-mtdll-x64.lib").read_text() == "dbg"
 
 
 def test_retry_build_breaks_on_first_success() -> None:


### PR DESCRIPTION
## Summary

Reverts the per-configuration `libs/<config>/` subdir layout introduced during modernization, and removes the flat-mirror workaround added in 57c91f3. te-builder now writes a single flat `libs/` dir — the contract downstream te-external consumers (libpng, freetype, ...) actually depend on.

## Why

te-external solutions emit configuration-suffixed artifact filenames (`zlib-debug-mtdll-x64.lib` vs `zlib-release-mtdll-x64.lib`), so Debug and Release outputs already coexist in a flat dir without collision. The earlier namespacing solved a problem that doesn't exist in practice.

The real problem it created: downstream projects in te-external reference dependencies via flat `libs/<dep>/*.lib` paths through junctions. With the namespaced layout, those projects couldn't find their deps unless te-builder ran a post-build mirror step. The 57c91f3 commit patched that by writing artifacts to **both** the per-config subdir and the flat dir — keeping the design flaw and leaving te-builder load-bearing for downstream linking.

This PR drops the namespacing entirely. Net effect:

- te-builder writes to `libs/` only — matching what downstream solutions expect
- te-builder is no longer a hard prerequisite for downstream link steps to find dependency libs
- cleanup-before-build is removed (it only swept a per-config subdir; MSBuild incremental rebuild + configuration-suffixed filenames already handle staleness correctly)

## Changes

- `orchestration.py`: removed `configuration_lib_dir` and `cleanup_libs_for_configuration`. Added `project_lib_dir`. `copy_libs_for_configuration` now writes flat only.
- `cli.py`: dropped the cleanup call and updated the debug log path.
- `tests/test_orchestration.py`: replaced the namespacing/collision tests with realistic flat-layout tests using configuration-suffixed filenames.

## Test plan

- [x] `pytest tests/` — 89 passed locally
- [x] `ruff check` and `ruff format --check` clean
- [ ] CI on this PR
- [ ] Trigger the downstream `c-pdf-to-text` workflow against this branch and confirm libpng/freetype link successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)