### PR TITLE
ci: bump actions/checkout and actions/setup-python to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -35,8 +35,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -51,12 +51,12 @@ jobs:
     needs: test
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: te-builder
       - name: Clone te-external (public sibling)
         run: git clone --depth 1 https://github.com/mazoea/te-external.git te-external
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install te-builder


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` → `@v6` and `actions/setup-python@v5` → `@v6` across all three jobs (lint, test, smoke-build)
- Clears the Node.js 20 deprecation warnings surfaced on recent runs (e.g. run [25939580963](https://github.com/mazoea/te-builder/actions/runs/25939580963)); both v6 releases run on Node.js 24, which becomes the GitHub Actions default in June 2026

## Test plan
- [ ] CI run on this branch shows no Node.js 20 deprecation annotations
- [ ] lint, test (ubuntu + windows), and smoke-build jobs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)