### PR TITLE
chore: adopt unified Mazoea AGENTS.md baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   push:
     branches: [master, main]
+    paths-ignore:
+      - '**/*.md'
+      - '.agents/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '.agents/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,94 @@
-# Security Notes
-- Never commit `.env` file
 
-# Critical principles:
-- Use TDD, always include test (but reasonable one), and plan tests before implementation.
-- Never add superfluous comments to self-explanatory names/methods/variables
-- if you comment, then use brief and precisely comments
-- always comment specific/complex/extraordinary things
-- before implementation, plan and create tests
-- before committing, all tests and pre-commit hooks must be executed and must pass
-- no silent fallbacks
-- do not invent patterns, read code first
-- fix root cause, not symptoms
-- Build Iteratively Start with minimal functionality and verify it works before adding complexity
-- File Organization: Balance file organization with simplicity - use an appropriate number of files for the project scale
-- Early Returns: Use to avoid nested conditions
-- DRY Code: Don't repeat yourself
-- Minimal Changes: Only modify code related to the task at hand
-- Simplicity: Prioritize simplicity and readability over clever solutions
+# Common Priorities
 
-# Python:
-- use f-string
-- logging with _logger = ...
-- argparse, tqdm (assume present)
-- DO not use print, use logging
-- strict typing everywhere
-- use requirements.txt for dependencies
+## Setup & Commands
+Keep these names so agents can rely on them across repos:
 
-# Pull Requests and Commits
-- check and suggest grammar improvements
-- check and report obsolete documentation that is not useful because it mostly repeats self-explanatory method and class names
-- Create a detailed message of what changed. Focus on the high level description of the problem it tries to solve, and how it is solved. Don't go into the specifics of the code unless it adds clarity.
-- NEVER ever mention a co-authored-by or similar aspects. In particular, never mention the tool used to create the commit message or PR.
-- Never commit and push on your own unless explicitly stated.
-- If you create a PR, always wait for the GitHub Copilot review. Address each comment: if it makes sense, like + resolve it; if it does not make sense, reply + dislike. Only after every comment is handled may you continue.
-- Always wait for the CI/CD pipeline to finish and be green. If it fails, investigate, fix, and iterate until it passes.
+- Run entry:      `scripts\startme.bat nopause`
+- Single test:    `pytest path/to/test_x.py::test_y -q`
+- Lint + format:  `pre-commit run --all-files`
+- C++ build:      `cmaker.continue.bat nopause`       *(CI: `build-scripts/ci.build.u22.bat nopause`)*
 
-At the end of a task, always briefly summarize the plan and the results.
+If you add or rename anything under `tools/`, update `scripts/startme.bat` in the same change.
 
-# Dir structure
+## Critical principles
+- **TDD**: plan tests, write a failing test, then implement. Tests pass before commit.
+- **No silent fallbacks**: no bare `except`, no `except Exception: pass`, no `or <default>` that swallows API errors. Raise or `_logger.error(...)`.
+- **Reuse before adding**: grep for an existing helper before writing a new one; cite the file you read in your reply.
+- **Diagnose, don't paper over**: if a test fails, explain the cause in your reply *before* changing code. Never edit a test only to make it pass.
+- **Minimal blast radius**: touch only code related to the task. No drive-by reformatting, re-importing, or renaming.
+- **Comments on non-obvious *why* only**: never restate function/variable names. One line where possible. Comment edge cases, known bugs, and the reason behind complex code.
 
-- ./scripts/startme.bat: if a tool is updated/added, this should be updated to reflect the latest changes
-- ./scripts: simple .bat files that call other scripts e.g., python scripts from ./tools
-- ./tools: directory of helper python scripts, should be organized into subdirectories
+## Code style
+
+### Python
+- f-strings only; no `%` or `.format()`.
+- Logging: `_logger = logging.getLogger(__name__)`. Never `print()`.
+- Strict typing on all new/changed signatures.
+- CLI: `argparse`. Progress: `tqdm`. Both assumed present.
+- Deps pinned in `requirements.txt`.
+- Use relative paths, use `/` separator.
+
+### C++
+- Follow the existing CMake structure. No new dependencies without discussion.
+- No raw `new` / `delete`. Use RAII / smart pointers.
+- Mark overrides `override`. Const-correct accessors.
+- Do not modify `third_party/**` or vendored sources.
+
+### Frontend / JS
+- Match the existing module pattern; do not introduce new build tooling without discussion.
+
+## Agent conduct
+- **May run without asking**: tests, linters, formatters, read-only git (`status`, `diff`, `log`), file reads, greps, builds.
+- **Must ask before**: installing deps, editing `requirements.txt` / `CMakeLists.txt`, network calls, any `git commit` / `push` / `tag`, deleting files, touching `.env*` or `secrets/`, modifying `third_party/**`.
+- Never bypass hooks (`--no-verify`, `--no-gpg-sign`).
+- Never amend or force-push to a protected branch.
+- When stuck, stop and ask. Do not invent APIs or file paths.
+- At the end of every task, post a short summary: plan, what changed, test results.
+
+## Before you commit
+1. `pre-commit run --all-files` is green.
+2. Tests are green.
+3. New behaviour has a test written *before* the implementation (TDD).
+
+## Pull requests and commits
+
+Commit / PR-body format (repos squash-merge, so the PR body becomes the commit message):
+
+    <area>: <imperative summary, <= 72 chars>
+
+    Why:  <1-3 sentences on the problem being solved>
+    How:  <1-3 sentences on the approach, only if non-obvious>
+    Refs: <issue or ticket id, optional>
+
+Rules:
+- Focus on *why*, not a line-by-line recap of the diff.
+- **Never** include `Co-Authored-By:` trailers, "Generated with" lines, or any mention of Claude / Codex / Copilot / Cursor / the tool used. CI enforces this; violations block merge.
+- **Never** `git push` or open a PR unless the human explicitly asks. Local commits are fine.
+- Reviewers and required checks come from branch protection + CODEOWNERS - do not try to bypass them.
+- Check and suggest grammar improvements in changed prose; flag obsolete documentation that only repeats self-explanatory names.
+
+When a PR is open (only after the human asks you to push):
+1. `gh pr checks <num> --watch --fail-fast` - block until green.
+2. Triage every Copilot review comment exactly once:
+   - Correct  -> fix in a new commit, thumbs-up, **resolve** the thread.
+   - Wrong    -> reply with a one-sentence reason, thumbs-down, resolve.
+   - Conflict -> stop, tag the human Code Owner, do not guess.
+3. After pushing fixes, re-request Copilot: `gh pr edit <num> --add-reviewer Copilot`. The automatic review does not re-run.
+4. Flaky CI -> `gh run rerun <id> --failed` **once**. A second failure is a real failure.
+5. Never force-push to `main` or `master` or any protected branch.
+
+## Security
+- Never stage files containing secrets: `.env`, `.env.*`, `*.pem`, `*.key`, anything under `secrets/`, anything matching `*credentials*`.
+- Never include the literal value of an env var in code, logs, or PR comments - reference by name only.
+- `.gitignore`, `gitleaks` pre-commit, and GitHub push protection are the safety net. Treat the rule as primary, not them.
+- If you find a secret already in git history: **stop**, surface it to the human, do not rewrite history yourself.
+
+## Cross-platform
+- **Shell**: do not use PowerShell on Windows.
+- **Wrappers**: every entry point in `scripts/` exists as `name.bat`; bash equivalents only when CI needs them.
+- **`nopause`**: `.bat` wrappers pause for humans by default; pass `nopause` as the last arg in CI and agent runs to skip prompts.
+
+## Layout
+- `scripts/`         thin `.bat` / `.sh` wrappers; `startme.bat` is the canonical entry point. Update it when tools change.
+- `tools/`           Python helpers, grouped into subdirectories by concern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ If you add or rename anything under `tools/`, update `scripts/startme.bat` in th
 ## Agent conduct
 - **May run without asking**: tests, linters, formatters, read-only git (`status`, `diff`, `log`), file reads, greps, builds.
 - **Must ask before**: installing deps, editing `requirements.txt` / `CMakeLists.txt`, network calls, any `git commit` / `push` / `tag`, deleting files, touching `.env*` or `secrets/`, modifying `third_party/**`.
-- Never bypass hooks (`--no-verify`, `--no-gpg-sign`).
+- Never bypass hooks (`--no-verify`) or disable commit signing (`--no-gpg-sign`).
 - Never amend or force-push to a protected branch.
 - When stuck, stop and ask. Do not invent APIs or file paths.
 - At the end of every task, post a short summary: plan, what changed, test results.


### PR DESCRIPTION
## Why

AGENTS.md has drifted across ~16 Mazoea repos: the same canonical 44-line variant plus per-repo extras, with typos (`File Organsiation`) and conflicting wording accumulated over time. This is the **pilot** for an org-wide unified baseline before bulk rollout to 10 more repos (te-caller, te-external-leptonica, te-server-checkpointer, te-testsite, c-pdf-to-text, mcp-backbone, ocr-services, devops, service-catalogue, te-qa-blackbox).

## How

**1. Replace `AGENTS.md` with the org-wide baseline.**

Source of truth: `c:/jm/maz/agent-baseline/AGENTS.md` (eventual `mazoea/agent-baseline` repo).

Material changes vs the canonical 44-line variant:
- **Cut** vague platitudes that don't change agent behaviour: "DRY", "Simplicity", "Build Iteratively", "Early Returns", "File Organization: Balance ... with simplicity".
- **Tighten** vague rules into falsifiable ones:
  - "no silent fallbacks" -> "no bare except, no except Exception: pass, no or <default> swallowing errors"
  - "fix root cause" -> "if a test fails, diagnose in your reply *before* changing code; never edit a test only to make it pass"
  - "do not invent patterns" -> "grep for an existing helper before writing a new one; cite the file you read"
- **Add** sections that were missing: Setup & Commands, Agent conduct, Cross-platform (PowerShell ban on Windows, nopause convention).
- **Rewrite** the PR loop into 5 concrete gh CLI steps with Copilot review triage, flaky-CI policy, and force-push protection.

**2. Add paths-ignore to ci.yml.**

Doc-only edits (AGENTS.md, README.md, etc.) no longer trigger CI rebuilds. Pattern matches `**/*.md` and `.agents/**`.

## Caveat

If lint / test / smoke-build are listed as **required status checks** in branch protection, doc-only PRs may sit pending forever. The proper fix is a sentinel `required-checks` workflow that always runs and short-circuits via `dorny/paths-filter` - out of scope for this PR but planned next.

## Test plan

- [ ] Diff of AGENTS.md reads as a coherent rewrite.
- [ ] CI does not trigger on this PR's changes (proves paths-ignore works) - except for `pull_request` paths-ignore needing the *target* branch's workflow definition; first AGENTS-only PR after merge is the real test.
- [ ] No `Co-Authored-By:` trailer in the commit.