### PR TITLE
chore: add gitleaks pre-commit hook + autoupdate revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,13 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.15.14
     hooks:
     -   id: ruff
         args: [--fix]
         exclude: ^tools/startme/startme\.py$
     -   id: ruff-format
         exclude: ^tools/startme/startme\.py$
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+    -   id: gitleaks


### PR DESCRIPTION
## Summary
- Adds [gitleaks](https://github.com/gitleaks/gitleaks) v8.30.0 as a pre-commit hook so staged changes are scanned for hardcoded secrets before reaching git history.
- Bumps existing hook revs via `pre-commit autoupdate`.

## Test plan
- [x] `gitleaks detect` on full history — no leaks found
- [x] `pre-commit run` against this commit — all hooks pass
- [ ] CI green on this PR