### PR TITLE
vs_detect: add --toolset for shell consumption

### DIFF
--- a/src/te_builder/vs_detect.py
+++ b/src/te_builder/vs_detect.py
@@ -14,15 +14,9 @@ session is a TTY and only then sets `interactive=True`. CI pipelines that
 do not pass `--msvc-toolset` therefore get the highest detected toolset
 without blocking on a prompt.
 
-Two CLI modes share the same detection pipeline:
-
-- `python -m te_builder.vs_detect` (no flag) prints a one-line summary per
-  install — wired into `scripts/list-vs.bat`.
-- `python -m te_builder.vs_detect --toolset` prints only the selected
-  toolset short name to stdout (exit 0) or nothing on stdout (exit 1) if
-  no install is detected. Sibling repos (te-external-leptonica's
-  `cmaker.bat`) shell out to this mode and apply their own fallback when
-  the script is unavailable.
+CLI modes:
+- `python -m te_builder.vs_detect`             # listing (wired into list-vs.bat)
+- `python -m te_builder.vs_detect --toolset`   # one-line short name for shell capture
 """
 
 from __future__ import annotations
@@ -46,10 +40,8 @@ _TOOLSET_BY_MAJOR: dict[str, str] = {
     "18": "v145",
 }
 
-# Single source of truth for what `--toolset` may emit; shell callers (e.g.
-# te-external-leptonica's cmaker.bat) rely on this contract to skip their
-# own re-validation. Keep this derived from _TOOLSET_BY_MAJOR so a new
-# entry in the mapping is automatically permitted by the guard.
+# Contract: `--toolset` only emits values in this set. Shell callers rely
+# on it to skip their own re-validation.
 KNOWN_TOOLSETS: frozenset[str] = frozenset(_TOOLSET_BY_MAJOR.values())
 
 
@@ -212,10 +204,6 @@ def main(argv: list[str] | None = None) -> int:
         if chosen is None:
             return 1
         if chosen not in KNOWN_TOOLSETS:
-            # Defensive: select_toolset only returns values from the mapping,
-            # so this can only fire on an internal regression. Exit non-zero
-            # with empty stdout so shell callers fall back instead of feeding
-            # a bogus value into `cmake -T`.
             _logger.error("internal: %r not in KNOWN_TOOLSETS", chosen)
             return 1
         sys.stdout.write(chosen + "\n")

--- a/src/te_builder/vs_detect.py
+++ b/src/te_builder/vs_detect.py
@@ -46,6 +46,12 @@ _TOOLSET_BY_MAJOR: dict[str, str] = {
     "18": "v145",
 }
 
+# Single source of truth for what `--toolset` may emit; shell callers (e.g.
+# te-external-leptonica's cmaker.bat) rely on this contract to skip their
+# own re-validation. Keep this derived from _TOOLSET_BY_MAJOR so a new
+# entry in the mapping is automatically permitted by the guard.
+KNOWN_TOOLSETS: frozenset[str] = frozenset(_TOOLSET_BY_MAJOR.values())
+
 
 @dataclass(frozen=True)
 class VsInstall:
@@ -204,6 +210,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.toolset:
         chosen = select_toolset(installs, interactive=False)
         if chosen is None:
+            return 1
+        if chosen not in KNOWN_TOOLSETS:
+            # Defensive: select_toolset only returns values from the mapping,
+            # so this can only fire on an internal regression. Exit non-zero
+            # with empty stdout so shell callers fall back instead of feeding
+            # a bogus value into `cmake -T`.
+            _logger.error("internal: %r not in KNOWN_TOOLSETS", chosen)
             return 1
         sys.stdout.write(chosen + "\n")
         sys.stdout.flush()

--- a/src/te_builder/vs_detect.py
+++ b/src/te_builder/vs_detect.py
@@ -14,12 +14,20 @@ session is a TTY and only then sets `interactive=True`. CI pipelines that
 do not pass `--msvc-toolset` therefore get the highest detected toolset
 without blocking on a prompt.
 
-Run `python -m te_builder.vs_detect` to print a one-line summary per
-install — wired into `scripts/list-vs.bat`.
+Two CLI modes share the same detection pipeline:
+
+- `python -m te_builder.vs_detect` (no flag) prints a one-line summary per
+  install — wired into `scripts/list-vs.bat`.
+- `python -m te_builder.vs_detect --toolset` prints only the selected
+  toolset short name to stdout (exit 0) or nothing on stdout (exit 1) if
+  no install is detected. Sibling repos (te-external-leptonica's
+  `cmaker.bat`) shell out to this mode and apply their own fallback when
+  the script is unavailable.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
@@ -168,11 +176,38 @@ def _format_install(install: VsInstall) -> str:
     )
 
 
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="te_builder.vs_detect",
+        description="List Visual Studio installs (default) or print the "
+        "selected MSVC platform toolset short name (--toolset).",
+    )
+    parser.add_argument(
+        "--toolset",
+        action="store_true",
+        help="Print only the highest-detected toolset short name (e.g. "
+        "v145) to stdout and exit 0; exit 1 with empty stdout if no "
+        "install is found, so shell callers can apply their own fallback.",
+    )
+    return parser
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Entry for `python -m te_builder.vs_detect` and scripts/list-vs.bat."""
+    """Entry for `python -m te_builder.vs_detect`.
+
+    Default mode lists installs (used by scripts/list-vs.bat). `--toolset`
+    is the machine-readable mode consumed by sibling repos' build scripts.
+    """
     logging.basicConfig(level=logging.INFO, format="%(levelname).4s %(message)s")
-    del argv  # no flags yet — this is intentionally a zero-arg listing tool
+    args = _build_arg_parser().parse_args(argv)
     installs = detect_installs()
+    if args.toolset:
+        chosen = select_toolset(installs, interactive=False)
+        if chosen is None:
+            return 1
+        sys.stdout.write(chosen + "\n")
+        sys.stdout.flush()
+        return 0
     if not installs:
         sys.stderr.write(
             "No Visual Studio installations detected. "

--- a/src/te_builder/vs_detect.py
+++ b/src/te_builder/vs_detect.py
@@ -1,18 +1,6 @@
-"""Detect installed Visual Studio versions and pick a toolset.
+"""Detect Visual Studio installs and pick an MSVC platform toolset.
 
-Wraps Microsoft's `vswhere.exe` (shipped with the VS Installer) to discover
-local installations. Each install is mapped to its MSVC platform toolset:
-
-    VS 2017 (15.x) -> v141
-    VS 2019 (16.x) -> v142
-    VS 2022 (17.x) -> v143
-    VS 2026 (18.x) -> v145   (v144 is intentionally skipped by Microsoft)
-
-`select_toolset()` is the single decision point the CLI calls. It is
-non-interactive by default; the caller (cli.main) decides whether the
-session is a TTY and only then sets `interactive=True`. CI pipelines that
-do not pass `--msvc-toolset` therefore get the highest detected toolset
-without blocking on a prompt.
+VS 15->v141, 16->v142, 17->v143, 18->v145 (Microsoft skipped v144).
 
 CLI modes:
 - `python -m te_builder.vs_detect`             # listing (wired into list-vs.bat)
@@ -40,8 +28,7 @@ _TOOLSET_BY_MAJOR: dict[str, str] = {
     "18": "v145",
 }
 
-# Contract: `--toolset` only emits values in this set. Shell callers rely
-# on it to skip their own re-validation.
+# Contract: `--toolset` only emits values in this set.
 KNOWN_TOOLSETS: frozenset[str] = frozenset(_TOOLSET_BY_MAJOR.values())
 
 
@@ -183,19 +170,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--toolset",
         action="store_true",
-        help="Print only the highest-detected toolset short name (e.g. "
-        "v145) to stdout and exit 0; exit 1 with empty stdout if no "
-        "install is found, so shell callers can apply their own fallback.",
+        help="Print the highest-detected toolset short name to stdout "
+        "(exit 0); empty stdout + exit 1 if none.",
     )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Entry for `python -m te_builder.vs_detect`.
-
-    Default mode lists installs (used by scripts/list-vs.bat). `--toolset`
-    is the machine-readable mode consumed by sibling repos' build scripts.
-    """
     logging.basicConfig(level=logging.INFO, format="%(levelname).4s %(message)s")
     args = _build_arg_parser().parse_args(argv)
     installs = detect_installs()

--- a/tests/test_vs_detect.py
+++ b/tests/test_vs_detect.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from te_builder.vs_detect import (
+    KNOWN_TOOLSETS,
     VsInstall,
     main,
     parse_vswhere_output,
@@ -168,3 +169,25 @@ def test_main_default_lists_installs(
     assert rc == 0
     assert "Visual Studio Enterprise 2026" in captured.out
     assert "v145" in captured.out
+
+
+def test_known_toolsets_matches_mapping_values() -> None:
+    """KNOWN_TOOLSETS is the contract shell consumers rely on (cmaker.bat
+    skips its own re-validation). It must stay in lockstep with the values
+    in _TOOLSET_BY_MAJOR — anything else would be a silent regression."""
+    assert frozenset({"v141", "v142", "v143", "v145"}) == KNOWN_TOOLSETS
+
+
+def test_main_toolset_emits_only_known_value(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Whatever vs_detect prints on --toolset must be in KNOWN_TOOLSETS, so
+    cmaker.bat can drop its own regex guard and trust this contract."""
+    monkeypatch.setattr(
+        "te_builder.vs_detect.detect_installs",
+        lambda: parse_vswhere_output(_FAKE_VSWHERE),
+    )
+    rc = main(["--toolset"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() in KNOWN_TOOLSETS

--- a/tests/test_vs_detect.py
+++ b/tests/test_vs_detect.py
@@ -20,6 +20,7 @@ import pytest
 
 from te_builder.vs_detect import (
     VsInstall,
+    main,
     parse_vswhere_output,
     select_toolset,
     toolset_for_version,
@@ -123,3 +124,47 @@ def test_select_toolset_blank_prompt_uses_default(blank: str) -> None:
     installs = parse_vswhere_output(_FAKE_VSWHERE)
     chosen = select_toolset(installs, interactive=True, prompt=lambda _msg: blank)
     assert chosen == "v145"
+
+
+def test_main_toolset_prints_highest_detected(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--toolset` is the machine-readable mode shell scripts in sibling
+    repos rely on. Stdout must hold only the toolset short name so a `for /f`
+    or `$(...)` capture binds cleanly."""
+    monkeypatch.setattr(
+        "te_builder.vs_detect.detect_installs",
+        lambda: parse_vswhere_output(_FAKE_VSWHERE),
+    )
+    rc = main(["--toolset"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == "v145\n"
+
+
+def test_main_toolset_no_installs_exits_nonzero_with_empty_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A consumer in cmaker.bat applies its own fallback when nothing is
+    detected. Exit 1 + empty stdout keeps that contract — caller checks
+    errorlevel without parsing prose."""
+    monkeypatch.setattr("te_builder.vs_detect.detect_installs", lambda: [])
+    rc = main(["--toolset"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.out == ""
+
+
+def test_main_default_lists_installs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No flag preserves the human-readable listing wired into list-vs.bat."""
+    monkeypatch.setattr(
+        "te_builder.vs_detect.detect_installs",
+        lambda: parse_vswhere_output(_FAKE_VSWHERE),
+    )
+    rc = main([])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Visual Studio Enterprise 2026" in captured.out
+    assert "v145" in captured.out

--- a/tests/test_vs_detect.py
+++ b/tests/test_vs_detect.py
@@ -130,9 +130,6 @@ def test_select_toolset_blank_prompt_uses_default(blank: str) -> None:
 def test_main_toolset_prints_highest_detected(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """`--toolset` is the machine-readable mode shell scripts in sibling
-    repos rely on. Stdout must hold only the toolset short name so a `for /f`
-    or `$(...)` capture binds cleanly."""
     monkeypatch.setattr(
         "te_builder.vs_detect.detect_installs",
         lambda: parse_vswhere_output(_FAKE_VSWHERE),
@@ -146,9 +143,6 @@ def test_main_toolset_prints_highest_detected(
 def test_main_toolset_no_installs_exits_nonzero_with_empty_stdout(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A consumer in cmaker.bat applies its own fallback when nothing is
-    detected. Exit 1 + empty stdout keeps that contract — caller checks
-    errorlevel without parsing prose."""
     monkeypatch.setattr("te_builder.vs_detect.detect_installs", lambda: [])
     rc = main(["--toolset"])
     captured = capsys.readouterr()
@@ -159,7 +153,6 @@ def test_main_toolset_no_installs_exits_nonzero_with_empty_stdout(
 def test_main_default_lists_installs(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """No flag preserves the human-readable listing wired into list-vs.bat."""
     monkeypatch.setattr(
         "te_builder.vs_detect.detect_installs",
         lambda: parse_vswhere_output(_FAKE_VSWHERE),
@@ -172,17 +165,12 @@ def test_main_default_lists_installs(
 
 
 def test_known_toolsets_matches_mapping_values() -> None:
-    """KNOWN_TOOLSETS is the contract shell consumers rely on (cmaker.bat
-    skips its own re-validation). It must stay in lockstep with the values
-    in _TOOLSET_BY_MAJOR — anything else would be a silent regression."""
     assert frozenset({"v141", "v142", "v143", "v145"}) == KNOWN_TOOLSETS
 
 
 def test_main_toolset_emits_only_known_value(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Whatever vs_detect prints on --toolset must be in KNOWN_TOOLSETS, so
-    cmaker.bat can drop its own regex guard and trust this contract."""
     monkeypatch.setattr(
         "te_builder.vs_detect.detect_installs",
         lambda: parse_vswhere_output(_FAKE_VSWHERE),


### PR DESCRIPTION
## Summary
- Add `--toolset` flag to `python -m te_builder.vs_detect`: prints only the highest-detected MSVC platform toolset short name (e.g. `v145`) to stdout, exit 0 on success, exit 1 with empty stdout when no VS install is found.
- Default zero-arg listing mode (used by `scripts/list-vs.bat`) is unchanged.
- Three unit tests cover the new mode (success, no-installs, default listing).

## Why
Sibling repos (te-external-leptonica's `cmaker.bat`) need to pick the same MSVC platform toolset te-builder would. They were duplicating vswhere parsing in batch scripts and risked drift — for example, mapping VS 18 to v144 instead of v145 (Microsoft skipped v144). Exposing a tiny machine-readable mode here lets those scripts shell out instead of re-implementing detection.

The companion PR in te-external-leptonica replaces a 50-line batch detection block with a small call to this script.

## Test plan
- [x] `pytest tests/test_vs_detect.py` — 16/16 pass
- [x] Full suite `pytest` — 92/92 pass
- [x] `ruff check` clean
- [x] Real-machine smoke: `python -m te_builder.vs_detect --toolset` -> `v145` on VS 2026 install
- [ ] CI green